### PR TITLE
Fix deprecations on PHP 8.1

### DIFF
--- a/src/Asn1/Der/Encoder.php
+++ b/src/Asn1/Der/Encoder.php
@@ -296,13 +296,13 @@ class Encoder implements EncoderInterface
     /**
      * Encode the length of the encoded value of an element.
      *
-     * @param string $encodedElementValue the encoded value of an element
+     * @param ?string $encodedElementValue the encoded value of an element
      *
      * @return string
      */
     protected function encodeLength($encodedElementValue)
     {
-        $length = strlen($encodedElementValue);
+        $length = $encodedElementValue === null ? 0 : strlen($encodedElementValue);
         if ($length < 128) {
             return chr($length);
         }


### PR DESCRIPTION
Hello ! 

It looks like $encodedElementValue can be null in encodeLength, which throw a deprecation notice on PHP 8.1. This PR fixes it, but it's maybe not the right way to do it. I'm open to hearing other suggestions on how to improve it further !